### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Arduino
 maintainer=Arduino <info@arduino.cc>
 sentence=Enables network connection (local and Internet) using the Arduino Ethernet board or shield. For all Arduino boards.
 paragraph=With this library you can use the Arduino Ethernet (shield or board) to connect to Internet. The library provides both Client and server functionalities. The library permits you to connect to a local network also with DHCP and to resolve DNS.
+category=Communication
 url=http://arduino.cc/en/Reference/Ethernet
 architectures=*


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library Ethernet2 is not valid. Setting to 'Uncategorized'` warning.
