### PR TITLE
Fix memory leak

### DIFF
--- a/src/Ethernet2.cpp
+++ b/src/Ethernet2.cpp
@@ -21,6 +21,9 @@ uint16_t EthernetClass::_server_port[MAX_SOCK_NUM] = { 0, };
 int EthernetClass::begin(void)
 {
   byte mac_address[6] ={0,};
+  if (_dhcp != NULL) {
+    delete _dhcp;
+  }
   _dhcp = new DhcpClass();
 
   // Initialise the basic info
@@ -78,6 +81,9 @@ void EthernetClass::begin(IPAddress local_ip, IPAddress dns_server, IPAddress ga
 #else
 int EthernetClass::begin(uint8_t *mac_address)
 {
+   if (_dhcp != NULL) {
+     delete _dhcp;
+   }
   _dhcp = new DhcpClass();
   // Initialise the basic info
   w5500.init(w5500_cspin);

--- a/src/Ethernet2.h
+++ b/src/Ethernet2.h
@@ -29,7 +29,7 @@ public:
   static uint8_t _state[MAX_SOCK_NUM];
   static uint16_t _server_port[MAX_SOCK_NUM];
 
-  EthernetClass() { w5500_cspin = 10; }
+  EthernetClass() { _dhcp = NULL; w5500_cspin = 10; }
   void init(uint8_t _cspin = 10) { w5500_cspin = _cspin; }
 
 #if defined(WIZ550io_WITH_MACADDRESS)


### PR DESCRIPTION
If the user calls twice or more times `Ethernet.begin`, the reference to the `_dhcp` object is lost and therefore a memory leak occurs.

This can be fixed easily by deleting the object before recreating it again.