### PR TITLE
adds support for reading options 12 and 15 of DHCP -> hostname and dns domain name

### DIFF
--- a/src/Dhcp.cpp
+++ b/src/Dhcp.cpp
@@ -345,7 +345,12 @@ uint8_t DhcpClass::parseDHCPResponse(unsigned long responseTimeout, uint32_t& tr
                     _dhcpUdpSocket.read(_dhcpDnsdomainName, opt_len);
                     _dhcpDnsdomainName[opt_len] = '\0';
                     break;
-                
+                case hostName:
+                    opt_len = _dhcpUdpSocket.read();
+                    _dhcpHostName = (char*)malloc(sizeof(char)*opt_len+1);
+                    _dhcpUdpSocket.read(_dhcpHostName, opt_len);
+                    _dhcpHostName[opt_len] = '\0';
+                    break;
                 case dhcpServerIdentifier :
                     
 					opt_len = _dhcpUdpSocket.read();
@@ -494,6 +499,11 @@ IPAddress DhcpClass::getDnsServerIp()
 char* DhcpClass::getDnsDomainName()
 {
     return _dhcpDnsdomainName;
+}
+
+char* DhcpClass::getHostName()
+{
+    return _dhcpHostName;
 }
 
 void DhcpClass::printByte(char * buf, uint8_t n ) {

--- a/src/Dhcp.cpp
+++ b/src/Dhcp.cpp
@@ -331,13 +331,19 @@ uint8_t DhcpClass::parseDHCPResponse(unsigned long responseTimeout, uint32_t& tr
                     break;
                 
                 case dns :
-                    
 					opt_len = _dhcpUdpSocket.read();
                     _dhcpUdpSocket.read(_dhcpDnsServerIp, 4);
                     for (int i = 0; i < opt_len-4; i++)
                     {
                         _dhcpUdpSocket.read();
                     }
+                    break;
+                    
+                case domainName:
+                    opt_len = _dhcpUdpSocket.read();
+                    _dhcpDnsdomainName = (char*)malloc(sizeof(char)*opt_len+1);
+                    _dhcpUdpSocket.read(_dhcpDnsdomainName, opt_len);
+                    _dhcpDnsdomainName[opt_len] = '\0';
                     break;
                 
                 case dhcpServerIdentifier :
@@ -483,6 +489,11 @@ IPAddress DhcpClass::getDhcpServerIp()
 IPAddress DhcpClass::getDnsServerIp()
 {
     return IPAddress(_dhcpDnsServerIp);
+}
+
+char* DhcpClass::getDnsDomainName()
+{
+    return _dhcpDnsdomainName;
 }
 
 void DhcpClass::printByte(char * buf, uint8_t n ) {

--- a/src/Dhcp.h
+++ b/src/Dhcp.h
@@ -144,6 +144,7 @@ private:
   uint8_t  _dhcpMacAddr[6];
   uint8_t  _dhcpLocalIp[4];
   char* _dhcpDnsdomainName;
+  char* _dhcpHostName;
   uint8_t  _dhcpSubnetMask[4];
   uint8_t  _dhcpGatewayIp[4];
   uint8_t  _dhcpDhcpServerIp[4];
@@ -172,6 +173,7 @@ public:
   IPAddress getDhcpServerIp();
   IPAddress getDnsServerIp();
   char* getDnsDomainName();
+  char* getHostName();
   
   int beginWithDHCP(uint8_t *, unsigned long timeout = 60000, unsigned long responseTimeout = 5000);  
   int checkLease();

--- a/src/Dhcp.h
+++ b/src/Dhcp.h
@@ -143,6 +143,7 @@ private:
   uint32_t _dhcpTransactionId;
   uint8_t  _dhcpMacAddr[6];
   uint8_t  _dhcpLocalIp[4];
+  char* _dhcpDnsdomainName;
   uint8_t  _dhcpSubnetMask[4];
   uint8_t  _dhcpGatewayIp[4];
   uint8_t  _dhcpDhcpServerIp[4];
@@ -170,6 +171,7 @@ public:
   IPAddress getGatewayIp();
   IPAddress getDhcpServerIp();
   IPAddress getDnsServerIp();
+  char* getDnsDomainName();
   
   int beginWithDHCP(uint8_t *, unsigned long timeout = 60000, unsigned long responseTimeout = 5000);  
   int checkLease();

--- a/src/Ethernet2.cpp
+++ b/src/Ethernet2.cpp
@@ -41,6 +41,7 @@ int EthernetClass::begin(void)
     w5500.setGatewayIp(_dhcp->getGatewayIp().raw_address());
     w5500.setSubnetMask(_dhcp->getSubnetMask().raw_address());
     _dnsServerAddress = _dhcp->getDnsServerIp();
+    _dnsDomainName = _dhcp->getDnsDomainName();
   }
 
   return ret;
@@ -100,6 +101,7 @@ int EthernetClass::begin(uint8_t *mac_address)
     w5500.setGatewayIp(_dhcp->getGatewayIp().raw_address());
     w5500.setSubnetMask(_dhcp->getSubnetMask().raw_address());
     _dnsServerAddress = _dhcp->getDnsServerIp();
+    _dnsDomainName = _dhcp->getDnsDomainName();
   }
 
   return ret;
@@ -157,6 +159,7 @@ int EthernetClass::maintain(){
         w5500.setGatewayIp(_dhcp->getGatewayIp().raw_address());
         w5500.setSubnetMask(_dhcp->getSubnetMask().raw_address());
         _dnsServerAddress = _dhcp->getDnsServerIp();
+        _dnsDomainName = _dhcp->getDnsDomainName();
         break;
       default:
         //this is actually a error, it will retry though
@@ -190,6 +193,10 @@ IPAddress EthernetClass::gatewayIP()
 IPAddress EthernetClass::dnsServerIP()
 {
   return _dnsServerAddress;
+}
+
+char* EthernetClass::dnsDomainName(){
+    return _dnsDomainName;
 }
 
 EthernetClass Ethernet;

--- a/src/Ethernet2.cpp
+++ b/src/Ethernet2.cpp
@@ -42,6 +42,7 @@ int EthernetClass::begin(void)
     w5500.setSubnetMask(_dhcp->getSubnetMask().raw_address());
     _dnsServerAddress = _dhcp->getDnsServerIp();
     _dnsDomainName = _dhcp->getDnsDomainName();
+    _hostName = _dhcp->getHostName();
   }
 
   return ret;
@@ -102,6 +103,7 @@ int EthernetClass::begin(uint8_t *mac_address)
     w5500.setSubnetMask(_dhcp->getSubnetMask().raw_address());
     _dnsServerAddress = _dhcp->getDnsServerIp();
     _dnsDomainName = _dhcp->getDnsDomainName();
+    _hostName = _dhcp->getHostName();
   }
 
   return ret;
@@ -160,6 +162,7 @@ int EthernetClass::maintain(){
         w5500.setSubnetMask(_dhcp->getSubnetMask().raw_address());
         _dnsServerAddress = _dhcp->getDnsServerIp();
         _dnsDomainName = _dhcp->getDnsDomainName();
+        _hostName = _dhcp->getHostName();
         break;
       default:
         //this is actually a error, it will retry though
@@ -197,6 +200,10 @@ IPAddress EthernetClass::dnsServerIP()
 
 char* EthernetClass::dnsDomainName(){
     return _dnsDomainName;
+}
+
+char* EthernetClass::hostName(){
+    return _hostName;
 }
 
 EthernetClass Ethernet;

--- a/src/Ethernet2.h
+++ b/src/Ethernet2.h
@@ -23,6 +23,7 @@ class EthernetClass {
 private:
   IPAddress _dnsServerAddress;
   char* _dnsDomainName;
+  char* _hostName;
   DhcpClass* _dhcp;
 public:
   uint8_t w5500_cspin;
@@ -62,6 +63,7 @@ public:
   IPAddress gatewayIP();
   IPAddress dnsServerIP();
   char* dnsDomainName();
+  char* hostName();
 
   friend class EthernetClient;
   friend class EthernetServer;

--- a/src/Ethernet2.h
+++ b/src/Ethernet2.h
@@ -22,6 +22,7 @@
 class EthernetClass {
 private:
   IPAddress _dnsServerAddress;
+  char* _dnsDomainName;
   DhcpClass* _dhcp;
 public:
   uint8_t w5500_cspin;
@@ -60,6 +61,7 @@ public:
   IPAddress subnetMask();
   IPAddress gatewayIP();
   IPAddress dnsServerIP();
+  char* dnsDomainName();
 
   friend class EthernetClient;
   friend class EthernetServer;


### PR DESCRIPTION
A minor change which reads and exposes option 15 of DHCP, the DNS domain name.
Added a method to make this available from the Ethernet class.

It's needed because when we want to resolve the local domains say "myserver" without using the full domain name (as it may change depending on the network you are connected on) we have to append the e.g ".domainname.com" or whatever that domain is, *IF it's returned by the DHCP server.


