### PR TITLE
Added SoftwareReset on init of chip to force default configuration

### DIFF
--- a/src/utility/w5500.cpp
+++ b/src/utility/w5500.cpp
@@ -32,7 +32,7 @@ void W5500Class::init(uint8_t ss_pin)
   delay(1000);
   initSS();
   SPI.begin();
-
+  w5500.swReset();
   for (int i=0; i<MAX_SOCK_NUM; i++) {
     uint8_t cntl_byte = (0x0C + (i<<5));
     write( 0x1E, cntl_byte, 2); //0x1E - Sn_RXBUF_SIZE

--- a/src/utility/w5500.h
+++ b/src/utility/w5500.h
@@ -186,6 +186,8 @@ public:
   inline void setRetransmissionTime(uint16_t timeout);
   inline void setRetransmissionCount(uint8_t _retry);
 
+  inline void swReset();
+
   inline void setPHYCFGR(uint8_t _val);
   inline uint8_t getPHYCFGR();
 
@@ -409,6 +411,10 @@ void W5500Class::setPHYCFGR(uint8_t _val) {
 uint8_t W5500Class::getPHYCFGR() {
 //  readPHYCFGR();
   return read(0x002E, 0x00);
+}
+
+void W5500Class::swReset() {
+  writeMR( (readMR() | 0x80) );
 }
 
 #endif


### PR DESCRIPTION
I was having problems with the W5500 chip when the dev board I had didn't have control over the chips reset pin.
If the library attempted to init() the Wiznet more than once without properly resetting it (i.e. the Arduino's reset switch was pushed, which did not reset the Wiznet), it would cause unpredictable results (including corrupt IP packets, etc.)

Let me know if I should instead implement it as an option of init().

Thanks.