### PR TITLE
fix memory leaks

### DIFF
--- a/src/Dhcp.cpp
+++ b/src/Dhcp.cpp
@@ -340,12 +340,18 @@ uint8_t DhcpClass::parseDHCPResponse(unsigned long responseTimeout, uint32_t& tr
                     break;
                     
                 case domainName:
+                    if(_dhcpDnsdomainName != NULL){
+                        free(_dhcpDnsdomainName);
+                    }
                     opt_len = _dhcpUdpSocket.read();
                     _dhcpDnsdomainName = (char*)malloc(sizeof(char)*opt_len+1);
                     _dhcpUdpSocket.read(_dhcpDnsdomainName, opt_len);
                     _dhcpDnsdomainName[opt_len] = '\0';
                     break;
                 case hostName:
+                    if(_dhcpHostName != NULL){
+                        free(_dhcpHostName);
+                    }
                     opt_len = _dhcpUdpSocket.read();
                     _dhcpHostName = (char*)malloc(sizeof(char)*opt_len+1);
                     _dhcpUdpSocket.read(_dhcpHostName, opt_len);
@@ -515,4 +521,13 @@ void DhcpClass::printByte(char * buf, uint8_t n ) {
     char c = m - 16 * n;
     *str-- = c < 10 ? c + '0' : c + 'A' - 10;
   } while(n);
+}
+
+DhcpClass::~DhcpClass(){
+  if(_dhcpDnsdomainName != NULL){
+    free(_dhcpDnsdomainName);
+  }
+  if(_dhcpHostName != NULL){
+    free(_dhcpHostName);
+  }
 }

--- a/src/Dhcp.h
+++ b/src/Dhcp.h
@@ -177,6 +177,7 @@ public:
   
   int beginWithDHCP(uint8_t *, unsigned long timeout = 60000, unsigned long responseTimeout = 5000);  
   int checkLease();
+  ~DhcpClass();
 };
 
 #endif


### PR DESCRIPTION
Fixes memory leaks from my previous patch, sorry didn't push those changes back then.

Please review and test carefully! Call begin() on a network where dhcpDomainName is set multiple times and see if memory being used is remaining the same


Thanks!