### PR TITLE
Support embedded MAC-Address on WIZ550io shields

### DIFF
--- a/src/Ethernet2.cpp
+++ b/src/Ethernet2.cpp
@@ -206,4 +206,8 @@ char* EthernetClass::hostName(){
     return _hostName;
 }
 
+void EthernetClass::macAddress(uint8_t *mac){
+    w5500.getMACAddress(mac);
+}
+
 EthernetClass Ethernet;

--- a/src/Ethernet2.h
+++ b/src/Ethernet2.h
@@ -64,6 +64,10 @@ public:
   IPAddress dnsServerIP();
   char* dnsDomainName();
   char* hostName();
+  
+  // Read the MAC address from the shield (useful when using WIZ550io where the Address can be set by the shield itself)
+  // Writes 6 bytes of MAC to the address provided
+  void macAddress(uint8_t *mac);
 
   friend class EthernetClient;
   friend class EthernetServer;

--- a/src/utility/w5500.cpp
+++ b/src/utility/w5500.cpp
@@ -27,12 +27,25 @@ uint8_t SPI_CS;
 
 void W5500Class::init(uint8_t ss_pin)
 {
+  #if defined(WIZ550io_WITH_MACADDRESS)
+  byte mac_address[6] ={0,};
+  #endif
   SPI_CS = ss_pin;
 
   delay(1000);
   initSS();
   SPI.begin();
+  
+  // Read the current MAC Address before doing the SW-Reset
+  // needed for the WIZ550io board which contains an embedded MAC Address (set only at HW-Reset)
+  #if defined(WIZ550io_WITH_MACADDRESS)
+  w5500.getMACAddress(mac_address);
+  #endif
   w5500.swReset();
+  #if defined(WIZ550io_WITH_MACADDRESS)
+  w5500.setMACAddress(mac_address);
+  #endif
+  
   for (int i=0; i<MAX_SOCK_NUM; i++) {
     uint8_t cntl_byte = (0x0C + (i<<5));
     write( 0x1E, cntl_byte, 2); //0x1E - Sn_RXBUF_SIZE

--- a/src/utility/w5500.h
+++ b/src/utility/w5500.h
@@ -20,6 +20,7 @@
 
 extern uint8_t SPI_CS;
 
+//#define WIZ550io_WITH_MACADDRESS // Use assigned MAC address of WIZ550io
 
 typedef uint8_t SOCKET;
 /*


### PR DESCRIPTION
The WIZ550io shields contain an embedded MAC address (which is also printed on a sticker on the shield).
According to the [datasheet](http://www.saelig.com/supplier/wiznet/WIZ550io.pdf), this MAC Address is lost when a Software-Reset is performed.
> A tiny MCU inside WIZ550io initialize W5500 with embedded MAC address and a default IP
address and it is triggered by nRESET. But SW reset clears all registers in W5500 and WIZ550io isn't
triggered to configure itself without handling nRESET. So, we recommend HW reset instead of SW
reset. Nevertheless if users want to use SW reset, **we recommend they read MAC address and
network information including IP address, Subnet mask and Gateway address before they do SW reset,
they write those information to WIZ550io after SW reset.**

A recent pull request #14 added the SoftwareReset into the init() function. In order to keep the MAC Address, i added `w5500.getMACAddress()` and `w5500.setMACAddress()`  before/after `w5500.swReset()`

The change is conditioned by `#if defined(WIZ550io_WITH_MACADDRESS)`, so if the line 
`//#define WIZ550io_WITH_MACADDRESS` in src/utility/w5500.h is left commented out, there should be no change in the code at all.

Additionally I added a new interface to the EthernetClass to be able to read the MAC Address: `void macAddress(uint8_t *mac);`