### PR TITLE
Added EthernetClient.remoteIP() to return the IPAddress of the remote machine

### DIFF
--- a/src/EthernetClient.cpp
+++ b/src/EthernetClient.cpp
@@ -156,6 +156,16 @@ uint8_t EthernetClient::status() {
   return w5500.readSnSR(_sock);
 }
 
+IPAddress EthernetClient::remoteIP(){
+  if (status() == SnSR::CLOSED) {
+    return INADDR_NONE;  
+  } else {
+    uint8_t addr[4];
+    w5500.readSnDIPR(_sock, (unsigned char*)&addr);
+    return IPAddress(addr);
+  }
+}
+
 // the next function allows us to use the client returned by
 // EthernetServer::available() as the condition in an if-statement.
 

--- a/src/EthernetClient.h
+++ b/src/EthernetClient.h
@@ -26,6 +26,8 @@ public:
   virtual operator bool();
   virtual bool operator==(const EthernetClient&);
   virtual bool operator!=(const EthernetClient& rhs) { return !this->operator==(rhs); };
+    
+  IPAddress remoteIP();
 
   friend class EthernetServer;
   


### PR DESCRIPTION
The ESP8266 Arduino core has the functionality to remoteIP() on the Client interface to get the address of the connected TCP client, and I thought it would be useful to expose a similar function in the EthernetClass.

This works both in client and server mode, which can be convenient if you are running a web server and want to know the IP of the client who has connected.

Let me know of any comments or Questions.

Thanks.