### PR TITLE
Add multicast support to Ethernet2 (analog to Ethernet library)

### DIFF
--- a/src/EthernetUdp2.h
+++ b/src/EthernetUdp2.h
@@ -100,6 +100,8 @@ public:
   virtual IPAddress remoteIP() { return _remoteIP; };
   // Return the port of the host who sent the current incoming packet
   virtual uint16_t remotePort() { return _remotePort; };
+  // Subscribe to multicast channel
+  virtual uint8_t beginMulticast(IPAddress ip, uint16_t port);
 };
 
 #endif


### PR DESCRIPTION
This adds the udp multicast from Ethernet library to Ethernet2.

I was in need for this and tested with a arduino mega 2560 and ethernet shield 2
