### PR TITLE
Add option for manual SPI transaction control.

### DIFF
--- a/src/utility/w5500.cpp
+++ b/src/utility/w5500.cpp
@@ -21,9 +21,12 @@
 // W5500 controller instance
 W5500Class w5500;
 
+bool W5500Class::auto_transaction_control = true;
+
 // SPI details
 SPISettings wiznet_SPI_settings(8000000, MSBFIRST, SPI_MODE0);
 uint8_t SPI_CS;
+
 
 void W5500Class::init(uint8_t ss_pin)
 {
@@ -102,21 +105,30 @@ void W5500Class::read_data(SOCKET s, volatile uint16_t src, volatile uint8_t *ds
 
 uint8_t W5500Class::write(uint16_t _addr, uint8_t _cb, uint8_t _data)
 {
-    SPI.beginTransaction(wiznet_SPI_settings);
+    if (auto_transaction_control)
+    {
+        SPI.beginTransaction(wiznet_SPI_settings);
+    }
     setSS();  
     SPI.transfer(_addr >> 8);
     SPI.transfer(_addr & 0xFF);
     SPI.transfer(_cb);
     SPI.transfer(_data);
     resetSS();
-    SPI.endTransaction();
+    if (auto_transaction_control)
+    {
+        SPI.endTransaction();
+    }
 
     return 1;
 }
 
 uint16_t W5500Class::write(uint16_t _addr, uint8_t _cb, const uint8_t *_buf, uint16_t _len)
 {
-    SPI.beginTransaction(wiznet_SPI_settings);
+    if (auto_transaction_control)
+    {
+        SPI.beginTransaction(wiznet_SPI_settings);
+    }
     setSS();
     SPI.transfer(_addr >> 8);
     SPI.transfer(_addr & 0xFF);
@@ -125,28 +137,40 @@ uint16_t W5500Class::write(uint16_t _addr, uint8_t _cb, const uint8_t *_buf, uin
         SPI.transfer(_buf[i]);
     }
     resetSS();
-    SPI.endTransaction();
+    if (auto_transaction_control)
+    {
+        SPI.endTransaction();
+    }
 
     return _len;
 }
 
 uint8_t W5500Class::read(uint16_t _addr, uint8_t _cb)
 {
-    SPI.beginTransaction(wiznet_SPI_settings);
+    if (auto_transaction_control)
+    {
+        SPI.beginTransaction(wiznet_SPI_settings);
+    }
     setSS();
     SPI.transfer(_addr >> 8);
     SPI.transfer(_addr & 0xFF);
     SPI.transfer(_cb);
     uint8_t _data = SPI.transfer(0);
     resetSS();
-    SPI.endTransaction();
+    if (auto_transaction_control)
+    {
+        SPI.endTransaction();
+    }
 
     return _data;
 }
 
 uint16_t W5500Class::read(uint16_t _addr, uint8_t _cb, uint8_t *_buf, uint16_t _len)
 { 
-    SPI.beginTransaction(wiznet_SPI_settings);
+    if (auto_transaction_control)
+    {
+        SPI.beginTransaction(wiznet_SPI_settings);
+    }
     setSS();
     SPI.transfer(_addr >> 8);
     SPI.transfer(_addr & 0xFF);
@@ -155,7 +179,10 @@ uint16_t W5500Class::read(uint16_t _addr, uint8_t _cb, uint8_t *_buf, uint16_t _
         _buf[i] = SPI.transfer(0);
     }
     resetSS();
-    SPI.endTransaction();
+    if (auto_transaction_control)
+    {
+        SPI.endTransaction();
+    }
 
     return _len;
 }
@@ -171,17 +198,32 @@ void W5500Class::execCmdSn(SOCKET s, SockCMD _cmd) {
 
 uint8_t W5500Class::readVersion(void)
 {
-    SPI.beginTransaction(wiznet_SPI_settings);
+    if (auto_transaction_control)
+    {
+        SPI.beginTransaction(wiznet_SPI_settings);
+    }
     setSS();
     SPI.transfer( 0x00 );
     SPI.transfer( 0x39 );
     SPI.transfer( 0x01);
     uint8_t _data = SPI.transfer(0);
     resetSS();
-    SPI.endTransaction();
+    if (auto_transaction_control)
+    {
+        SPI.endTransaction();
+    }
 
     return _data;
 }
 
+void W5500Class::beginTransaction()
+{
+    SPI.beginTransaction(wiznet_SPI_settings);
+}
+
+void W5500Class::endTransaction()
+{
+    SPI.endTransaction();
+}
 
 //#endif

--- a/src/utility/w5500.h
+++ b/src/utility/w5500.h
@@ -196,6 +196,21 @@ public:
   uint16_t getTXFreeSize(SOCKET s);
   uint16_t getRXReceivedSize(SOCKET s);
   
+  /**
+   * @brief begin SPI transaction
+   *
+   * This function is meant to be used while using
+   * manual transaction control
+   */
+  void beginTransaction();
+
+  /**
+   * @brief end SPI transaction
+   *
+   * This function is meant to be used while using
+   * manual transaction control
+   */
+  void endTransaction();
 
   // W5500 Registers
   // ---------------
@@ -332,6 +347,7 @@ private:
 
 public:
   static const uint16_t SSIZE = 2048; // Max Tx buffer size
+  static bool auto_transaction_control; // enable automatic transaction control
 private:
   static const uint16_t RSIZE = 2048; // Max Rx buffer size
 


### PR DESCRIPTION
While using Ethernet2 library on stm32 (Nucleo bard),
there apperas problem with reinitializing SPI on each write() call.
This commit allows to manually call beginTransaction before
handling ethernet, and endTransaction when finished with it.

This change affects only `W5500Class`. Adds static member `auto_transaction_control` 
which controls calling `SPI.beginTransaction` and `SPI.endTransaction` in `write()` and `read()`
functions. 

By default it is set to `true` so that code works normally, but user can set it to
`false` and use in code like this: 

```
void loop() {
  w5500.beginTransaction();
  web_server.poll();  // which talk with w5500
  w5500.endTransaction();
  // ...
}
```

This is approach to fix #28. 
Tested on Nucleo F091RC with `WebServer` example.
With automatic transaction control page load takes around 800 ms (measured in developer tools),
and with manual around 430 ms.