### PR TITLE
Add support ESP32 module

### DIFF
--- a/src/EthernetServer.cpp
+++ b/src/EthernetServer.cpp
@@ -13,18 +13,35 @@ EthernetServer::EthernetServer(uint16_t port)
   _port = port;
 }
 
+void EthernetServer::init()
+{
+	for (int sock = 0; sock < MAX_SOCK_NUM; sock++) {
+		EthernetClient client(sock);
+		if (client.status() == SnSR::CLOSED) {
+			socket(sock, SnMR::TCP, _port, 0);
+			listen(sock);
+			EthernetClass::_server_port[sock] = _port;
+			break;
+		}
+	}
+}
+
+// 20181016 https://kmpelectronics.eu/ Plamen Kovandjiev - We added support for ESP32.
+#ifdef ESP32
+void EthernetServer::begin(uint16_t port)
+{
+	if (port) {
+		_port = port;
+	}
+
+	init();
+}
+#else
 void EthernetServer::begin()
 {
-  for (int sock = 0; sock < MAX_SOCK_NUM; sock++) {
-    EthernetClient client(sock);
-    if (client.status() == SnSR::CLOSED) {
-      socket(sock, SnMR::TCP, _port, 0);
-      listen(sock);
-      EthernetClass::_server_port[sock] = _port;
-      break;
-    }
-  }  
+	init();
 }
+#endif
 
 void EthernetServer::accept()
 {

--- a/src/EthernetServer.h
+++ b/src/EthernetServer.h
@@ -10,10 +10,16 @@ public Server {
 private:
   uint16_t _port;
   void accept();
+  void init();
 public:
   EthernetServer(uint16_t);
   EthernetClient available();
+  // 20181016 https://kmpelectronics.eu/ Plamen Kovandjiev - We added support for ESP32.
+#ifdef ESP32
+  virtual void begin(uint16_t port = 0);
+#else
   virtual void begin();
+#endif
   virtual size_t write(uint8_t);
   virtual size_t write(const uint8_t *buf, size_t size);
   using Print::write;


### PR DESCRIPTION
**Scope of change**
We added support for ESP32 platform. It was because ESP32 wanted some different EthernetClient.begin(uint16_t) method. 

**Limitation**
It doesn't.

**Tests**
We tested this change on many platform ESP32 (exactly), MKR Zero and etc. All they worked.